### PR TITLE
Renderer content implements serializable

### DIFF
--- a/renderers/src/main/java/com/pedrogomez/renderers/RendererContent.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/RendererContent.java
@@ -1,14 +1,12 @@
 package com.pedrogomez.renderers;
 
-import java.io.Serializable;
-
 /**
  * Wrapper to use with {@link RendererBuilder} for type or class bindings.
  *
  * @author alberto.ballano
  */
 @SuppressWarnings("unused")
-public class RendererContent<T extends Serializable> implements Serializable {
+public class RendererContent<T> {
 
     private T item;
     private int type = -1;

--- a/renderers/src/main/java/com/pedrogomez/renderers/RendererContent.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/RendererContent.java
@@ -8,7 +8,7 @@ import java.io.Serializable;
  * @author alberto.ballano
  */
 @SuppressWarnings("unused")
-public class RendererContent<T> implements Serializable {
+public class RendererContent<T extends Serializable> implements Serializable {
 
     private T item;
     private int type = -1;

--- a/renderers/src/main/java/com/pedrogomez/renderers/RendererContent.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/RendererContent.java
@@ -1,12 +1,14 @@
 package com.pedrogomez.renderers;
 
+import java.io.Serializable;
+
 /**
  * Wrapper to use with {@link RendererBuilder} for type or class bindings.
  *
  * @author alberto.ballano
  */
 @SuppressWarnings("unused")
-public class RendererContent<T> {
+public class RendererContent<T> implements Serializable {
 
     private T item;
     private int type = -1;

--- a/renderers/src/main/java/com/pedrogomez/renderers/SerializableRendererContent.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/SerializableRendererContent.java
@@ -1,0 +1,20 @@
+package com.pedrogomez.renderers;
+
+import java.io.Serializable;
+
+/**
+ * Wrapper to use with {@link RendererBuilder} for type or class bindings that implements the serializable interface.
+ *
+ * @author angelo.marchesin
+ */
+@SuppressWarnings("unused")
+public class SerializableRendererContent<T extends Serializable> extends RendererContent<T> implements Serializable {
+
+    /**
+     * @param item Content of the wrapper.
+     * @param type The type within the list.
+     */
+    public SerializableRendererContent(T item, int type) {
+        super(item, type);
+    }
+}


### PR DESCRIPTION
_Renderer content implements serializable._
`RendererContent` now implements serializable. This allows it to be bundled in the saved instance's package without issues.

**Reviewer**:
- [ ] @Shyish 
