### PR TITLE
Types are now enforced for bind methods.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.1.3'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.1'
     }
 }

--- a/renderers/src/main/java/com/pedrogomez/renderers/RendererBuilder.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/RendererBuilder.java
@@ -99,8 +99,8 @@ public class RendererBuilder<T> {
      * Initializes a RendererBuilder without Renderers. Using this constructor some
      * binding configuration is needed.
      */
-    public static ExtendedRendererBuilder create() {
-        return new Builder<>(new RendererBuilder<>());
+    public static <T> ExtendedRendererBuilder<T> create() {
+        return new Builder<>(new RendererBuilder<T>());
     }
 
     /**
@@ -289,9 +289,9 @@ public class RendererBuilder<T> {
     }
 
     public interface ExtendedRendererBuilder<T> extends BaseRendererBuilder<T> {
-        BindedExtendedRendererBuilder<T> bind(Class clx, Renderer prototype);
+        <Type> BindedExtendedRendererBuilder<T> bind(Class<? extends Type> clx, Renderer<Type> prototype);
 
-        BindedExtendedRendererBuilder<T> bind(int type, Renderer prototype);
+        <Type> BindedExtendedRendererBuilder<T> bind(int type, Renderer<RendererContent<Type>> prototype);
     }
 
     public static class Builder<T> implements SimpleRendererBuilder<T>, BindedExtendedRendererBuilder<T> {

--- a/renderers/src/test/java/com/pedrogomez/renderers/ObjectRendererContentRenderer.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/ObjectRendererContentRenderer.java
@@ -1,0 +1,29 @@
+package com.pedrogomez.renderers;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import java.util.List;
+
+/**
+ * Renderer created only for testing purposes.
+ *
+ * @author alberto.ballano
+ */
+public class ObjectRendererContentRenderer extends Renderer<RendererContent<Object>> {
+
+    private View view;
+
+    @Override
+    protected View inflate(LayoutInflater inflater, ViewGroup parent) {
+        return view;
+    }
+
+    @Override
+    public void render(List<Object> payloads) { }
+
+    public void setView(View view) {
+        this.view = view;
+    }
+}

--- a/renderers/src/test/java/com/pedrogomez/renderers/RendererBuilderTest.java
+++ b/renderers/src/test/java/com/pedrogomez/renderers/RendererBuilderTest.java
@@ -97,7 +97,7 @@ public class RendererBuilderTest {
         renderer.setView(mockedRendererView);
 
         RendererBuilder rendererBuilder = RendererBuilder.create()
-              .bind(0, renderer)
+              .bind(String.class, renderer)
               .getRendererBuilder()
               .withParent(mockedParent)
               .withLayoutInflater(mockedLayoutInflater)
@@ -114,7 +114,7 @@ public class RendererBuilderTest {
         renderer.setView(mockedRendererView);
 
         RendererBuilder rendererBuilder = RendererBuilder.create()
-              .bind(0, renderer)
+              .bind(String.class, renderer)
               .getRendererBuilder()
               .withParent(mockedParent)
               .withLayoutInflater(mockedLayoutInflater)
@@ -131,7 +131,7 @@ public class RendererBuilderTest {
         renderer.setView(mockedRendererView);
 
         RendererBuilder rendererBuilder = RendererBuilder.create()
-              .bind(0, renderer)
+              .bind(String.class, renderer)
               .getRendererBuilder()
               .withParent(mockedParent)
               .withLayoutInflater(null)
@@ -148,7 +148,7 @@ public class RendererBuilderTest {
         renderer.setView(mockedRendererView);
 
         RendererBuilder rendererBuilder = RendererBuilder.create()
-              .bind(0, renderer)
+              .bind(String.class, renderer)
               .getRendererBuilder()
               .withParent(null)
               .withLayoutInflater(mockedLayoutInflater)
@@ -163,10 +163,10 @@ public class RendererBuilderTest {
     public void shouldAddPrototypeAndConfigureRendererBindingForType() {
         int type = 1;
         RendererBuilder rendererBuilder = RendererBuilder.create()
-              .bind(type, new ObjectRenderer())
+              .bind(type, new ObjectRendererContentRenderer())
               .getRendererBuilder();
 
-        assertEquals(ObjectRenderer.class, rendererBuilder.getPrototypeClass(
+        assertEquals(ObjectRendererContentRenderer.class, rendererBuilder.getPrototypeClass(
               new RendererContent<>(new Object(), type)));
     }
 
@@ -175,8 +175,8 @@ public class RendererBuilderTest {
         int type = 1;
         int anotherType = 2;
         RendererBuilder rendererBuilder = RendererBuilder.create()
-              .bind(type, new ObjectRenderer())
-              .bind(anotherType, new ObjectRenderer())
+              .bind(type, new ObjectRendererContentRenderer())
+              .bind(anotherType, new ObjectRendererContentRenderer())
               .getRendererBuilder();
 
         rendererBuilder.getPrototypeClass(new RendererContent<>(new Object(), -1));


### PR DESCRIPTION
This means that is no longer possible to mess up bindings of a class with a Renderer of a different one:

`bind(String.class, VideoRenderer())`

Having VideoRenderer extending `Renderer<Video>`, this will cause a compilation error. The same applies to type bindings:

`bind(SOME_INTEGER_TYPE, VideoRenderer())`

This will show a compilation error since `VideoRenderer` needs to extend `Renderer<RendererContent>`