### PR TITLE
Changed RendererViewHolder to be public

### DIFF
--- a/renderers/src/main/java/com/pedrogomez/renderers/RendererViewHolder.java
+++ b/renderers/src/main/java/com/pedrogomez/renderers/RendererViewHolder.java
@@ -21,7 +21,7 @@ import android.support.v7.widget.RecyclerView;
  * RecyclerView.ViewHolder extension created to be able to use Renderer classes in RecyclerView
  * widgets. This class will be completely hidden to the library clients.
  */
-class RendererViewHolder extends RecyclerView.ViewHolder {
+public class RendererViewHolder extends RecyclerView.ViewHolder {
 
     private final Renderer renderer;
 


### PR DESCRIPTION
Changed to public to match the [original repository](https://github.com/pedrovgs/Renderers/commit/358adeb81c60b155a8f7a4141d15880f9ea5c311#diff-bd9979abc0a8896ca79615424c7f2de9) and so that it's possible to cast `ViewHolder`s obtained from a `RecyclerView`.